### PR TITLE
INT-1730 | Added sorting column to mlist table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 /vendor
 /composer.lock
+
+.idea/

--- a/Classes/Domain/Model/Mlist.php
+++ b/Classes/Domain/Model/Mlist.php
@@ -47,6 +47,13 @@ class Mlist extends AbstractEntity
     protected $feUsers;
 
     /**
+     * The sorting order.
+     *
+     * @var int
+     */
+    protected $sorting;
+
+    /**
      * Constructor.
      *
      * @return void
@@ -181,5 +188,26 @@ class Mlist extends AbstractEntity
     public function setFeUsers(ObjectStorage $feUsers)
     {
         $this->feUsers = $feUsers;
+    }
+
+    /**
+     * Return the sorting order.
+     *
+     * @return int
+     */
+    public function getSorting()
+    {
+        return $this->sorting;
+    }
+
+    /**
+     * Set the sorting order.
+     *
+     * @param  int $sorting
+     * @return void
+     */
+    public function setSorting($sorting)
+    {
+        $this->sorting = $sorting;
     }
 }

--- a/Classes/Domain/Repository/MlistRepository.php
+++ b/Classes/Domain/Repository/MlistRepository.php
@@ -93,6 +93,8 @@ class MlistRepository extends Repository
 
         $q->matching($q->contains('feUsers', [$user->getUid()]));
 
+        $q->setOrderings(['sorting' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING]);
+
         return $q->execute();
     }
 
@@ -107,6 +109,8 @@ class MlistRepository extends Repository
         $q = $this->createQuery();
 
         $q->matching($q->logicalNot($q->contains('feUsers', [$user->getUid()])));
+
+        $q->setOrderings(['sorting' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING]);
 
         return $q->execute();
     }

--- a/Configuration/TCA/tx_tevmailchimp_domain_model_mlist.php
+++ b/Configuration/TCA/tx_tevmailchimp_domain_model_mlist.php
@@ -25,6 +25,7 @@ return [
                 hidden,
                 name,
                 description,
+                sorting,
                 --div--;Subscribers,
                 fe_users,
                 --div--;Mailchimp Config,
@@ -89,6 +90,15 @@ return [
                 'maxitems' => 9999,
                 'foreign_table' => 'fe_users',
                 'MM' => 'tx_tevmailchimp_domain_model_mlist_fe_user_mm'
+            ]
+        ],
+        'sorting' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:tev_mailchimp/Resources/Private/Language/locallang_tca.xml:tx_tevmailchimp_domain_model_mlist.sorting',
+            'config' => [
+                'type' => 'input',
+                'size' => '30',
+                'eval' => 'trim,int'
             ]
         ]
     ]

--- a/Resources/Private/Language/locallang_tca.xml
+++ b/Resources/Private/Language/locallang_tca.xml
@@ -13,6 +13,7 @@
             <label index="tx_tevmailchimp_domain_model_mlist.mc_list_id">Mailchimp List ID</label>
             <label index="tx_tevmailchimp_domain_model_mlist.mc_created_at">Time created in Mailchimp</label>
             <label index="tx_tevmailchimp_domain_model_mlist.fe_users">Subscribers</label>
+            <label index="tx_tevmailchimp_domain_model_mlist.sorting">Sorting Order</label>
         </languageKey>
     </data>
 </T3locallang>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE tx_tevmailchimp_domain_model_mlist (
     cruser_id int(11) unsigned DEFAULT '0' NOT NULL,
     deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
     hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
+    sorting int(11) DEFAULT '0' NOT NULL,
     name varchar(255) DEFAULT '' NOT NULL,
     description varchar(255) DEFAULT '' NOT NULL,
     mc_list_id varchar(20) DEFAULT '' NOT NULL,


### PR DESCRIPTION
## Tracker/JIRA Issue
* https://jira.3ev.info/browse/INT-1730

## Dev Notes
* Needed a way to sort the list of newsletters a user could subscribe to. This change adds a sorting column to the mlist table and references it when checking what newsletters a user is and isn't subscribed to

## Deployment Steps
* Create a new release for this repository
* Run ``composer install`` on whatever project it is required on
* Clear TYPO3 install tool caches in the appropriate project if possible
